### PR TITLE
Remove unused `coords` variable from `Geometry.from_xyz()`

### DIFF
--- a/src/easyxtb/geometry.py
+++ b/src/easyxtb/geometry.py
@@ -211,7 +211,6 @@ class Geometry:
             # Guard against empty final line or line starting with something other than
             # an element symbol
             if len(atom_parts) >= 4 and atom_parts[0].isalpha():
-                coords = [float(n) for n in atom_parts[1:4]]
                 atoms.append(Atom(atom_parts[0], *[float(n) for n in atom_parts[1:4]]))
         return Geometry(atoms, charge, spin, _comment=xyz_lines[1])
 


### PR DESCRIPTION
The intention seemed to be that instead of using
```python
atoms.append(Atom(atom_parts[0], *[float(n) for n in atom_parts[1:4]]))
```
it would use
```python
coords = [float(n) for n in atom_parts[1:4]]
atoms.append(Atom(atom_parts[0], *coords))
```
but in my opinion the extra creation of a variable is unnecessary, and anyone who understands the `.xyz` format will understand what is going on there.